### PR TITLE
Added ReSpec class 'removeOnSave' to some of the mapping table UI.

### DIFF
--- a/js/html-api-map.js
+++ b/js/html-api-map.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
             //array to store table rows' @ids
             var ids = [];
 			//add switch to view as single table or details/summary
-			$viewSwitch = $('<button class="switch-view">View as a single table</button>').on('click', function() {
+			$viewSwitch = $('<button class="switch-view removeOnSave">View as a single table</button>').on('click', function() {
 				//array to store summary/tr @ids
 				//if current view is details/summary
 				if ($detailsContainer.is(':visible')) {
@@ -102,8 +102,8 @@ $(document).ready(function() {
 				$detailsContainer.append(details);
 			});
 			//add 'expand/collapse all' functionality
-			var $expandAllButton = $('<button class="expand">Expand All</button>');
-			var $collapseAllButton = $('<button disabled="disabled" class="collapse">Collapse All</button>');
+			var $expandAllButton = $('<button class="expand removeOnSave">Expand All</button>');
+			var $collapseAllButton = $('<button disabled="disabled" class="collapse removeOnSave">Collapse All</button>');
 			$detailsContainer.prepend($expandAllButton, $collapseAllButton);
 			var expandCollapseDetails = function($detCont, action) {
 				$detCont.find('details').each(function() {
@@ -132,7 +132,7 @@ $(document).ready(function() {
 				$detailsContainer.find('button.expand').removeAttr('disabled');
 			});
 			//add collapsible table columns functionality
-			var $showHideCols = $('<div class="show-hide-cols"><span>Show/Hide Columns: </span></div>');
+			var $showHideCols = $('<div class="show-hide-cols removeOnSave"><span>Show/Hide Columns: </span></div>');
 			for(var i=0, len=colHeaders.length; i < len; i++) {
 				var $showHideColButton = $('<button class="hide-col" title="Hide this column"><span class="action">Hide</span> ' + colHeaders[i] + '</button>').on('click', function() {
 					var index = $(this).index() + 1;


### PR DESCRIPTION
In a previous email to Jason, I wrote:

> I'm also getting multiple copies of the "View by X" button and the "Show/hide" buttons after saving a
> snapshot.  Apparently, the best way to set things up is to show the full table and then save a snapshot.  But then, the buttons are also saved in the snapshot. When the snapshot is loaded the mapping script creates them as before resulting in multiple copies of the buttons.  The document has to be tweaked to remove the extra copies.  Still looking for a better way ...

Looking at how ReSpec removes its own UI revealed a "removeOnSave" class.  This pull request adds that class to the relevant mapping table buttons, and they are not saved in the snapshot.  But, as before, they are generated by the mapping table script when the snapshot is loaded.

The only (minor) downside is that the buttons will always have the "removeOnSave" class even in the final document, where it is extra fluff.
